### PR TITLE
Allow custom style guide UUIDs in MCP tools

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -129,8 +129,7 @@ const TOOLS = [
                 },
                 style_guide: {
                     type: 'string',
-                    description: 'Style guide to follow',
-                    enum: ['ap', 'chicago', 'microsoft', 'proofpoint'],
+                    description: 'Style guide to follow (predefined: ap, chicago, microsoft, proofpoint) or custom UUID',
                     default: 'microsoft'
                 }
             },
@@ -162,8 +161,7 @@ const TOOLS = [
                 },
                 style_guide: {
                     type: 'string',
-                    description: 'Style guide to check against',
-                    enum: ['ap', 'chicago', 'microsoft'],
+                    description: 'Style guide to check against (predefined: ap, chicago, microsoft) or custom UUID',
                     default: 'microsoft'
                 }
             },
@@ -195,8 +193,7 @@ const TOOLS = [
                 },
                 style_guide: {
                     type: 'string',
-                    description: 'Style guide for suggestions',
-                    enum: ['ap', 'chicago', 'microsoft'],
+                    description: 'Style guide for suggestions (predefined: ap, chicago, microsoft) or custom UUID',
                     default: 'microsoft'
                 }
             },

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,8 +214,7 @@ const TOOLS: Tool[] = [
         },
         style_guide: {
           type: 'string',
-          description: 'Style guide to follow',
-          enum: ['ap', 'chicago', 'microsoft', 'proofpoint'],
+          description: 'Style guide to follow (predefined: ap, chicago, microsoft, proofpoint) or custom UUID',
           default: 'microsoft'
         }
       },
@@ -247,8 +246,7 @@ const TOOLS: Tool[] = [
         },
         style_guide: {
           type: 'string',
-          description: 'Style guide to check against',
-          enum: ['ap', 'chicago', 'microsoft'],
+          description: 'Style guide to check against (predefined: ap, chicago, microsoft) or custom UUID',
           default: 'microsoft'
         }
       },
@@ -280,8 +278,7 @@ const TOOLS: Tool[] = [
         },
         style_guide: {
           type: 'string',
-          description: 'Style guide for suggestions',
-          enum: ['ap', 'chicago', 'microsoft'],
+          description: 'Style guide for suggestions (predefined: ap, chicago, microsoft) or custom UUID',
           default: 'microsoft'
         }
       },


### PR DESCRIPTION
Remove enum restrictions from style_guide parameters in all three tools (acrolinx_rewrite, acrolinx_check, acrolinx_suggestions) to allow users to specify custom style guide UUIDs in addition to predefined names.